### PR TITLE
fix: helm chart namespace management

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Add the Helm repository and install the chart:
 helm repo add mondu-ai https://mondu-ai.github.io/eks-pod-identity-webhook
 helm repo update
 helm install eks-pod-identity-webhook mondu-ai/eks-pod-identity-webhook \
-  --namespace aws-pod-identity-webhook --create-namespace
+  --namespace aws-pod-identity-webhook
 ```
 
 ### Configuration
@@ -105,7 +105,7 @@ You can customize the installation by providing values:
 
 ```bash
 helm install eks-pod-identity-webhook mondu-ai/eks-pod-identity-webhook \
-  --namespace aws-pod-identity-webhook --create-namespace \
+  --namespace aws-pod-identity-webhook \
   --set env.AWS_REGION=us-west-2
 ```
 

--- a/charts/eks-pod-identity-webhook/Chart.yaml
+++ b/charts/eks-pod-identity-webhook/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: eks-pod-identity-webhook
 description: Helm chart for deploying the EKS Pod Identity Webhook
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "0.1.1"

--- a/charts/eks-pod-identity-webhook/templates/_helpers.tpl
+++ b/charts/eks-pod-identity-webhook/templates/_helpers.tpl
@@ -11,9 +11,5 @@
 {{- end -}}
 
 {{- define "eks-pod-identity-webhook.namespace" -}}
-{{- if .Values.namespace.name -}}
-{{- .Values.namespace.name -}}
-{{- else -}}
 {{- .Release.Namespace -}}
-{{- end -}}
 {{- end -}}

--- a/charts/eks-pod-identity-webhook/templates/certificate.yaml
+++ b/charts/eks-pod-identity-webhook/templates/certificate.yaml
@@ -3,17 +3,17 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "eks-pod-identity-webhook.fullname" . }}-tls
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "eks-pod-identity-webhook.name" . }}
 spec:
   secretName: {{ .Values.certManager.secretName }}
   duration: {{ .Values.certManager.certificate.duration }}
   renewBefore: {{ .Values.certManager.certificate.renewBefore }}
-  commonName: {{ include "eks-pod-identity-webhook.fullname" . }}-svc.{{ .Values.namespace.name }}.svc
+  commonName: {{ include "eks-pod-identity-webhook.fullname" . }}-svc.{{ .Release.Namespace }}.svc
   dnsNames:
-    - {{ include "eks-pod-identity-webhook.fullname" . }}-svc.{{ .Values.namespace.name }}.svc.cluster.local
-    - {{ include "eks-pod-identity-webhook.fullname" . }}-svc.{{ .Values.namespace.name }}.svc
+    - {{ include "eks-pod-identity-webhook.fullname" . }}-svc.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ include "eks-pod-identity-webhook.fullname" . }}-svc.{{ .Release.Namespace }}.svc
   issuerRef:
     name: {{ .Values.certManager.issuerName }}
     kind: Issuer

--- a/charts/eks-pod-identity-webhook/templates/clusterrolebinding.yaml
+++ b/charts/eks-pod-identity-webhook/templates/clusterrolebinding.yaml
@@ -11,4 +11,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}
-    namespace: {{ .Values.namespace.name }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/eks-pod-identity-webhook/templates/deployment.yaml
+++ b/charts/eks-pod-identity-webhook/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "eks-pod-identity-webhook.fullname" . }}-deployment
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "eks-pod-identity-webhook.name" . }}
     app.kubernetes.io/instance: {{ include "eks-pod-identity-webhook.fullname" . }}

--- a/charts/eks-pod-identity-webhook/templates/issuer.yaml
+++ b/charts/eks-pod-identity-webhook/templates/issuer.yaml
@@ -3,7 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ .Values.certManager.issuerName }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "eks-pod-identity-webhook.name" . }}
 spec:

--- a/charts/eks-pod-identity-webhook/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/eks-pod-identity-webhook/templates/mutatingwebhookconfiguration.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: {{ include "eks-pod-identity-webhook.name" . }}
   annotations:
     {{- if not .Values.existingTLSSecret }}
-    cert-manager.io/inject-ca-from: {{ .Values.namespace.name }}/{{ include "eks-pod-identity-webhook.fullname" . }}-tls
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "eks-pod-identity-webhook.fullname" . }}-tls
     {{- end }}
 webhooks:
   - name: aws-pod-identity-webhook.mondu.internal
@@ -15,7 +15,7 @@ webhooks:
     failurePolicy: Fail
     clientConfig:
       service:
-        namespace: {{ .Values.namespace.name }}
+        namespace: {{ .Release.Namespace }}
         name: {{ include "eks-pod-identity-webhook.fullname" . }}-svc
         path: "/mutate"
         port: 443

--- a/charts/eks-pod-identity-webhook/templates/namespace.yaml
+++ b/charts/eks-pod-identity-webhook/templates/namespace.yaml
@@ -1,8 +1,0 @@
-{{- if .Values.namespace.create }}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.namespace.name }}
-  labels:
-    app.kubernetes.io/name: {{ include "eks-pod-identity-webhook.name" . }}
-{{- end }}

--- a/charts/eks-pod-identity-webhook/templates/service.yaml
+++ b/charts/eks-pod-identity-webhook/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "eks-pod-identity-webhook.fullname" . }}-svc
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "eks-pod-identity-webhook.name" . }}
     app.kubernetes.io/instance: {{ include "eks-pod-identity-webhook.fullname" . }}

--- a/charts/eks-pod-identity-webhook/templates/serviceaccount.yaml
+++ b/charts/eks-pod-identity-webhook/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "eks-pod-identity-webhook.name" . }}
 {{- end }}

--- a/charts/eks-pod-identity-webhook/values.yaml
+++ b/charts/eks-pod-identity-webhook/values.yaml
@@ -9,9 +9,6 @@ serviceAccount:
   create: true
   name: aws-pod-identity-webhook-sa
 
-namespace:
-  create: true
-  name: ""  # Uses Release.Namespace when empty
 
 certManager:
   enabled: true


### PR DESCRIPTION
## Summary
- drop namespace creation template from Helm chart
- use `.Release.Namespace` throughout the templates
- remove namespace config from values
- bump chart version to 0.1.1
- update README install instructions

## Testing
- `make lint`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684269d15a8883269ff53a1c18bfb950