### PR TITLE
chore: bump Go to 1.26 (CVE-2025-68121)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     tags: [ 'v*' ]
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, reopened]
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
 
 jobs:
   quick-checks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 # Set up build environment
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module eks-iam-pod-identity-webhook
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/gin-gonic/gin v1.11.0


### PR DESCRIPTION
## Summary

Bumps Go from 1.25 to 1.26 across the project to address CVE-2025-68121 — a crypto/tls session resumption bypass rated CVSS 10.

Changes:
- Dockerfile base image: `golang:1.25-alpine` → `golang:1.26-alpine`
- go.mod: `go 1.25.0` → `go 1.26.0`
- CI/CD and PR check workflows: `GO_VERSION: '1.25'` → `'1.26'`

All tests pass locally with Go 1.26.0 (lint, vet, security scan, unit tests with race detector).