### PR TITLE
chore: bump Go to 1.26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     tags: [ 'v*' ]
 
 env:
-  GO_VERSION: '1.26'
+  GO_VERSION: '1.26.2'
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, reopened]
 
 env:
-  GO_VERSION: '1.26'
+  GO_VERSION: '1.26.2'
 
 jobs:
   quick-checks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 
 # Set up build environment
 ARG TARGETOS

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,8 +1,6 @@
 module eks-pod-identity-webhook-e2e
 
-go 1.24.0
-
-toolchain go1.24.3
+go 1.26.2
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module eks-iam-pod-identity-webhook
 
-go 1.26.0
+go 1.26.2
 
 require (
 	github.com/gin-gonic/gin v1.11.0


### PR DESCRIPTION
Bumps Go from 1.26.0 to 1.26.2 across go.mod, Dockerfile, e2e module, and CI workflows.