### PR TITLE
chore: group k8s deps so Dependabot bumps them in lockstep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      k8s:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
## Why

Every weekly Dependabot run for the k8s dependencies fails, and the resulting PRs never go green. The updater bumps the `k8s.io/*` modules **one at a time**, which produces an incompatible version skew — e.g. `client-go` moves to `0.36.x` while `k8s.io/api` stays at `0.35.0`. The aggregated `client-go/kubernetes` clientset then imports typed clients for API groups that no longer exist in the mismatched `k8s.io/api`, so `go mod tidy` blows up:

```
k8s.io/client-go/kubernetes imports
  k8s.io/api/autoscaling/v2beta1: cannot find module providing package ...
  k8s.io/api/autoscaling/v2beta2: ...
  k8s.io/api/scheduling/v1alpha1: ...
```

The k8s ecosystem modules are only ever compatible when they share the same minor version, so they have to move together.

## What

Group `k8s.io/*` and `sigs.k8s.io/*` in `dependabot.yml` so they're bumped in a single lockstep PR instead of separate, un-buildable ones.

Once this lands, the current stuck single-module PRs (`client-go`, `apimachinery`, `controller-runtime`) can be closed — Dependabot will re-open them as one grouped update.
