### PR TITLE
chore: pin golangci-lint to a fixed version and fix goconst violations

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -31,8 +31,13 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
 
+    - name: Lint
+      run: |
+        go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+        golangci-lint run ./...
+
     - name: Run CI pipeline
-      run: make ci
+      run: make deps vet security test
 
     - name: Check build
       run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ version: "2"
 
 run:
   timeout: 5m
-  go: '1.25'
+  go: '1.26'
   modules-download-mode: readonly
   allow-parallel-runners: true
 

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,7 @@ test-coverage: ## Run tests with coverage
 # Lint the code (excludes e2e which is a separate module)
 lint: ## Run linter
 	@echo "Running linter..."
-	@which golangci-lint >/dev/null 2>&1 || { \
-		echo "Installing golangci-lint v2..."; \
-		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest; \
-	}
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 	golangci-lint run ./...
 
 # Format the code

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -61,6 +62,9 @@ const (
 
 	// maxRoleSessionNameLength is the AWS STS limit for role session names
 	maxRoleSessionNameLength = 64
+
+	// jsonPatchOpAdd is the JSON Patch "add" operation
+	jsonPatchOpAdd = "add"
 )
 
 var (
@@ -116,7 +120,7 @@ func init() {
 
 	// Check if debug mode is enabled
 	logLevel := os.Getenv("LOG_LEVEL")
-	debugMode = logLevel == "debug" || logLevel == "DEBUG"
+	debugMode = strings.EqualFold(logLevel, "debug")
 
 	if debugMode {
 		debugLogger.Println("Debug logging enabled")
@@ -530,10 +534,10 @@ func (whs *WebhookServer) createVolumePatches(pod *corev1.Pod) []JSONPatchEntry 
 
 	volumePath := "/spec/volumes"
 	if pod.Spec.Volumes == nil {
-		patches = append(patches, JSONPatchEntry{Op: "add", Path: volumePath, Value: []corev1.Volume{}})
+		patches = append(patches, JSONPatchEntry{Op: jsonPatchOpAdd, Path: volumePath, Value: []corev1.Volume{}})
 	}
 	patches = append(patches, JSONPatchEntry{
-		Op:    "add",
+		Op:    jsonPatchOpAdd,
 		Path:  volumePath + "/-",
 		Value: volume,
 	})
@@ -593,10 +597,10 @@ func (whs *WebhookServer) createVolumeMountPatches(container *corev1.Container, 
 
 	vmMountPath := containerPath + "/volumeMounts"
 	if container.VolumeMounts == nil {
-		patches = append(patches, JSONPatchEntry{Op: "add", Path: vmMountPath, Value: []corev1.VolumeMount{}})
+		patches = append(patches, JSONPatchEntry{Op: jsonPatchOpAdd, Path: vmMountPath, Value: []corev1.VolumeMount{}})
 	}
 	patches = append(patches, JSONPatchEntry{
-		Op:   "add",
+		Op:   jsonPatchOpAdd,
 		Path: vmMountPath + "/-",
 		Value: corev1.VolumeMount{
 			Name:      awsTokenVolumeName,
@@ -622,7 +626,7 @@ func (whs *WebhookServer) createEnvironmentPatches(container *corev1.Container, 
 
 	envPath := containerPath + "/env"
 	if container.Env == nil && len(envVarsToAdd) > 0 {
-		patches = append(patches, JSONPatchEntry{Op: "add", Path: envPath, Value: []corev1.EnvVar{}})
+		patches = append(patches, JSONPatchEntry{Op: jsonPatchOpAdd, Path: envPath, Value: []corev1.EnvVar{}})
 	}
 
 	for _, newEnvVar := range envVarsToAdd {
@@ -636,7 +640,7 @@ func (whs *WebhookServer) createEnvironmentPatches(container *corev1.Container, 
 		}
 		if !envExists {
 			patches = append(patches, JSONPatchEntry{
-				Op:    "add",
+				Op:    jsonPatchOpAdd,
 				Path:  envPath + "/-",
 				Value: newEnvVar,
 			})


### PR DESCRIPTION
## Why

`Quick Checks` started failing on unrelated PRs with `goconst` errors on `main.go` — code nobody had touched. Root cause is version drift: the `lint` target installed `golangci-lint@latest` on the fly, so every CI run silently picked up whatever the newest release was. A newer version tightened `goconst` and began flagging pre-existing literals. Any PR (and eventually `main`) would break the same way, on the linter's schedule rather than ours.

Same disease as unpinned dependencies — the toolchain has to be deterministic.

## What

**Pin golangci-lint to `2.12.2`**, everywhere it's installed:

- `make lint` now runs `go install …@v2.12.2` instead of `@latest`.
- CI does the same in a plain `run` step (the org Actions allowlist only permits the SHA-pinned actions already in use, so no linter action is introduced).

**Fix the two real `goconst` findings** the repo's own config asks for (it enables `goconst` with `min-occurrences: 3`):

- Extracted the JSON Patch `"add"` operation into a `jsonPatchOpAdd` constant (6 call sites).
- Collapsed the `"debug"`/`"DEBUG"` log-level check to `strings.EqualFold`.

Also bumped `run.go` in `.golangci.yml` from `1.25` to `1.26` to match the module.

Verified locally: `golangci-lint 2.12.2` → **0 issues**.

## Notes

`gosec` and `goimports` are still installed via `go install …@latest` in the Makefile — same drift risk, worth pinning in a follow-up. Left out here to keep this focused on the linter that actually broke.
