### PR TITLE
docs: architecture docs, coding style, and backfilled ADRs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,95 @@
+# Architecture
+
+A Kubernetes **mutating admission webhook** that brings EKS-style IRSA (IAM Roles for Service Accounts) to *non-EKS* clusters — GKE, AKS, on-prem, anything with an OIDC issuer. When a pod's ServiceAccount carries the `eks.amazonaws.com/role-arn` annotation, the webhook injects a projected ServiceAccount token and the AWS SDK env vars so the SDK can `AssumeRoleWithWebIdentity` against AWS STS — no static credentials.
+
+One thing ships: a static Go binary in a `scratch` container (`ghcr.io`), deployed via the Helm chart in a **separate repo** (`mondu-ai/helm-charts-community`).
+
+## Runtime shape
+
+- **HTTP layer:** Gin, TLS-only, listening on `:8443`.
+  - `POST /mutate` — the admission entry point (`handleMutatePod`).
+  - `GET /healthz` — liveness/readiness (`handleHealthz`).
+- **Kube client:** in-cluster config by default; `KUBECONFIG` env overrides for local runs.
+- **TLS:** certificate is served through controller-runtime `certwatcher`, wired into `tls.Config.GetCertificate`. Cert rotation is picked up live — **no pod restart** on secret rotation.
+- **Shutdown:** SIGINT/SIGTERM trigger a 5s graceful `server.Shutdown`; the certwatcher goroutine is cancelled via context.
+
+## Request lifecycle
+
+A single `/mutate` request walks this chain (all in `main.go`):
+
+```
+handleMutatePod
+  → parseAdmissionReview        decode AdmissionReview, reject nil request
+  → processAdmissionRequest
+      → isValidPodResource      non-pod → ALLOW unmutated (fail-open)
+      → deserializePod          decode failure → DENY (fail-closed)
+      → createMutationResponse
+          → createPatch
+              → getRoleArnFromServiceAccount   ← live k8s API call
+              → createVolumePatches            pod-level token volume
+              → createContainerPatches
+                  → addMutationsToContainers   init + main containers
+                      → createVolumeMountPatches
+                      → createEnvironmentPatches
+```
+
+The output is a **JSON Patch** (`[]JSONPatchEntry`) attached to the `AdmissionResponse`. Empty patch → response says "no mutation needed" but still allows.
+
+## The injection contract (hard invariant)
+
+The webhook exists to be **wire-compatible with EKS IRSA**. These constants are load-bearing — the AWS SDK and the OIDC trust policy on the AWS side expect exactly these values. Changing any of them breaks credential resolution for every consumer and **counts as drift**, not refactoring.
+
+| Concern | Value | Source of truth |
+|---|---|---|
+| SA annotation read | `eks.amazonaws.com/role-arn` | `awsRoleArnAnnotationKey` |
+| Token audience | `sts.amazonaws.com` | `projectedTokenAudience` |
+| Token mount path | `/var/run/secrets/eks.amazonaws.com/serviceaccount` | `awsTokenMountPath` |
+| Token expiry | 3600s | `projectedTokenExpiration` |
+| Injected env | `AWS_WEB_IDENTITY_TOKEN_FILE`, `AWS_ROLE_ARN`, `AWS_REGION`, `AWS_DEFAULT_REGION`, `AWS_ROLE_SESSION_NAME` | const block, top of `main.go` |
+
+`AWS_ROLE_SESSION_NAME` is derived by `generateRoleSessionName`: pod name → `generateName`+UnixNano → `namespace-serviceaccount` → `namespace-pod`, then `sanitizeSessionName` restricts it to the AWS STS charset `[A-Za-z0-9+=,.@_-]` and truncates to 64 chars. The fallback chain exists because controller-created pods often have no `.Name` at admission time.
+
+## Behavioral invariants
+
+These are not incidental — preserve them across changes:
+
+- **Asymmetric fail semantics.** Non-pod resources are *allowed unmutated*. A pod that fails to deserialize, or whose patch fails to build, is *denied* (`Allowed: false`). Don't flatten this into "always allow" or "always deny".
+- **Idempotency.** Every `create*Patches` helper checks for the volume / mount / env var *by name* before adding it. A user-set env var is never overwritten; a re-admitted pod isn't double-patched.
+- **Injection reaches all containers.** Both `initContainers` and `containers` get the mount + env vars; the token volume is added once at pod level.
+- **RBAC coupling.** `getRoleArnFromServiceAccount` does a live `ServiceAccounts().Get()` — the annotation lives on the *ServiceAccount*, not the pod. The deployment therefore needs RBAC `get` on `serviceaccounts`. That RBAC lives in the **chart repo**, so adding new API calls here requires a coordinated change there.
+
+## Code layout
+
+The service is a single flat `package main` — there is no `internal/` or `pkg/`, and that's deliberate (see the linter limits in `docs/coding-style.md`; small composable functions, not layered packages). `main.go` is organized in bands: constants → package vars/loggers → `Config`/`WebhookServer`/`JSONPatchEntry` types → `main` and setup (`parseConfig`, `setupKubernetesConfig`, `setupRouter`, `createHTTPServer`, `startServer`) → the handler/patch methods.
+
+Two **separate Go modules** live here:
+
+- **Root** — `eks-iam-pod-identity-webhook` (go 1.26): the webhook + `main_test.go` (unit tests, table-driven, testify).
+- **`e2e/`** — `eks-pod-identity-webhook-e2e` (go 1.24): a standalone module. `TestMain` provisions a Kind cluster, builds the local image as `eks-pod-identity-webhook:e2e-test`, and installs the webhook using the **published Helm chart** (`pullPolicy=Never`, `certManager.enabled=false`). It exercises the real chart contract, not local manifests. `e2e/framework/` holds the cluster/helm/cert/pod-builder helpers.
+
+`go test ./...`, `make lint`, `vet`, and `security` from the root **do not touch `e2e/`** — it's a different module, explicitly excluded in the Makefile and `.golangci.yml`.
+
+## External boundaries
+
+- **Kubernetes API server** — inbound admission calls; outbound `ServiceAccounts().Get()`.
+- **Helm chart** (`mondu-ai/helm-charts-community`) — owns Deployment, RBAC, Service, MutatingWebhookConfiguration, TLS wiring. Not in this repo.
+- **Container registry** (`ghcr.io/mondu-ai/eks-pod-identity-webhook`) — CI builds multi-arch (amd64/arm64) images on push/tag.
+- **AWS STS** — not called by the webhook; the *injected pod* calls it at runtime using the projected token.
+
+## Keeping This Document Accurate
+
+This project is a single flat package, so drift shows up in specific, greppable places. After implementation changes, verify:
+
+- **Injection contract table** matches the const block at the top of `main.go`. Check the values directly:
+  `grep -nE 'awsRoleArnAnnotationKey|projectedTokenAudience|awsTokenMountPath|projectedTokenExpiration|awsWebIdentityTokenFileEnv|awsRoleArnEnv|awsRegionEnv|awsDefaultRegionEnv|awsRoleSessionNameEnv' main.go`
+  Any changed value is either a documented, intentional break of EKS compatibility (rare — update this doc *and* flag it loudly) or a bug.
+- **Endpoints** in the "Runtime shape" section match `setupRouter`:
+  `grep -nE 'router\.(POST|GET)' main.go`
+- **Config surface** matches `parseConfig`:
+  `grep -n 'flag\.StringVar' main.go`
+- **Request-lifecycle chain** still reflects the real call graph — if handlers/helpers are renamed, split, or reordered, update the diagram.
+- **RBAC coupling** — if a new k8s API call is added (anything beyond the SA `Get`), note it here and confirm the chart repo's RBAC grants it.
+- **Module boundary** — if `e2e/`'s Kind/Helm flow changes (new `--set` flags, different chart source), update the "Code layout" and boundaries sections. Chart `--set` flags live in `e2e/framework/helm.go`.
+- **Go version** stays aligned across `go.mod`, the Dockerfile builder, and CI (`setup-go`).
+
+Run `/pilat:arch-sync` to check automatically.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A Kubernetes **mutating admission webhook** that gives pods in *non-EKS* clusters (GKE, AKS, on-prem — anything with an OIDC issuer) the same AWS IRSA experience as EKS. When a pod's ServiceAccount carries the `eks.amazonaws.com/role-arn` annotation, the webhook injects a projected SA token volume, its mount, and the AWS SDK env vars so the SDK can `AssumeRoleWithWebIdentity`. mondu-ai fork; distributed as a `ghcr.io` container and installed via the Helm chart in a **separate repo** (`mondu-ai/helm-charts-community`).
+
+## Commands
+
+```bash
+make test           # unit tests (root module only, -race -timeout=30s)
+make lint           # installs golangci-lint v2.12.2 (pinned) and runs it
+make ci             # deps fmt vet lint security test — mirrors PR CI
+make test-coverage  # writes coverage.out + coverage.html
+make security       # gosec → results.sarif (medium severity/confidence)
+make e2e            # builds docker image, spins up Kind, runs e2e module
+make e2e-retain     # same, but keeps the cluster for debugging
+make e2e-clean      # kind delete cluster --name eks-webhook-e2e
+```
+
+Run a single unit test (root is a single `package main`):
+
+```bash
+go test -race -run 'TestGenerateRoleSessionName$' -v .
+```
+
+## Architecture
+
+Everything runs from one file, `main.go` (`package main`). There is no `internal/` or `pkg/`. Flow of a request:
+
+`handleMutatePod` → `parseAdmissionReview` → `processAdmissionRequest` → `createMutationResponse` → `createPatch` → the `create*Patches` helpers, which emit **JSON Patch** ops.
+
+Load-bearing behavior to keep in mind before changing anything:
+
+- **The webhook calls the k8s API mid-admission.** `getRoleArnFromServiceAccount` does a live `ServiceAccounts().Get()` to read the `role-arn` annotation off the SA (the annotation is on the *ServiceAccount*, not the pod). This is why the deployment needs RBAC `get` on serviceaccounts — a behavior change here can require a matching RBAC change in the Helm chart repo.
+- **Fail semantics are asymmetric.** Non-pod resources are *allowed unmutated* (fail-open). But a pod that fails to deserialize, or a patch that fails to build, is *denied* (`Allowed=false`). Preserve this split.
+- **Injection is idempotent.** Every `create*Patches` helper checks for an existing volume / mount / env var by name and skips it rather than duplicating or overwriting. Env vars already set by the user are never clobbered.
+- **All containers + init containers** get the mount and env vars; the token volume is added once at the pod level.
+- **Session-name generation** (`generateRoleSessionName`) has a fallback chain: pod name → `generateName`+UnixNano → `namespace-serviceaccount` → `namespace-pod`, then sanitized to the AWS STS charset `[A-Za-z0-9+=,.@_-]` and truncated to 64 chars. Pods created by controllers often have no `.Name` yet at admission time — that's what the chain handles.
+- **TLS certs hot-reload** via controller-runtime `certwatcher` wired into `tls.Config.GetCertificate`; the watcher goroutine is started in `startServer`. Rotating the cert secret must *not* require a pod restart (there's an e2e test asserting this).
+- HTTP layer is **Gin** (`/mutate` POST, `/healthz` GET) over TLS on `:8443`. Kube config resolves from `KUBECONFIG` if set, else in-cluster.
+
+Config comes from flags (`-tls-cert-path`, `-tls-key-path`, `-listen-addr`, `-aws-region`) plus env (`LOG_LEVEL=debug` toggles debug logs, `ENV`, `AWS_REGION`). Logging is hand-rolled leveled loggers (`logInfo`/`logWarn`/`logError`/`logDebug`), not a structured logger.
+
+## Two Go modules — this trips people up
+
+- **Root module** `eks-iam-pod-identity-webhook` (go 1.26) — the webhook + `main_test.go`.
+- **`e2e/` module** `eks-pod-identity-webhook-e2e` (go 1.24) — a *separate* module.
+
+Consequences: `go test ./...`, `make lint`, `vet`, and `security` from the root **do not touch `e2e/`** (it's excluded in the Makefile and `.golangci.yml`). To work on e2e, `cd e2e` first.
+
+The e2e suite (`e2e/framework/`) creates a Kind cluster, builds the local Docker image tagged `eks-pod-identity-webhook:e2e-test`, and installs the webhook using the **published Helm chart** pulled from `https://mondu-ai.github.io/helm-charts-community` with `image.pullPolicy=Never` + `certManager.enabled=false`. So e2e exercises the real chart, not local manifests — a breaking change to the injected shape may need a coordinated change in the chart repo. All e2e tests share one cluster via `TestMain`; you can't run a single e2e test without that setup path running first. `make e2e` requires Docker.
+
+## Conventions
+
+- Go version lives in go.mod (1.26), the Dockerfile builder (`golang:1.26-alpine`), and CI (`setup-go` → 1.26). Keep those three aligned when bumping.
+- `golangci-lint` v2 with strict `funlen` (100 lines / 50 statements) and `cyclop`/`gocyclo` (complexity 15). This is *why* `main.go` is decomposed into many small methods — new code must stay under those limits rather than growing a handler.
+- Runtime image is `FROM scratch`, non-root `65534`. The build is `CGO_ENABLED=0` static; a Go builder bump changes the stdlib linked into the final binary (crypto/tls, net/http), so it is not "builder-stage-only".
+
+## Releases
+
+CI (`ci.yml` → `docker` job) publishes images to `ghcr.io/mondu-ai/eks-pod-identity-webhook`:
+
+- **Push to `main`/`develop`** → `sha-<short>` and `<branch>` tags only. Dev images, not a release.
+- **Push a `v*` tag** → semver tags (`X.Y.Z`, `X.Y`, `X`) plus `latest` (`latest` is skipped for pre-releases — versions containing `-`). This is the only path to a versioned/`latest` image.
+
+No `v*` tag = no versioned release. The workflow only pushes images — there is no GitHub Release object and no CHANGELOG.
+
+## Architecture Docs
+
+Read these in order before making changes:
+
+1. `README.md` — what the webhook is, how to install it
+2. `ARCHITECTURE.md` — runtime shape, request lifecycle, the IRSA injection contract, invariants
+3. `docs/coding-style.md` — enforced linter limits and the conventions behind the flat layout
+4. `docs/adr/` — architectural decision records (start at `README.md`)
+
+Keep these docs accurate: the IRSA injection contract and the fail-open/fail-closed semantics are load-bearing invariants, not incidental. After an implementation cycle that touches the mutation path, config surface, endpoints, or the module boundary, run `/pilat:arch-sync` to detect and reconcile drift.

--- a/docs/adr/0001-mutating-webhook-for-irsa-on-non-eks.md
+++ b/docs/adr/0001-mutating-webhook-for-irsa-on-non-eks.md
@@ -1,0 +1,30 @@
+# ADR-0001: Mutating admission webhook for IRSA on non-EKS clusters
+
+- **Status:** accepted
+- **Date:** 2025-06-05
+
+> Backfilled from the initial commit. Records the founding architecture as it stands.
+
+## Context
+
+Pods running outside EKS — GKE, AKS, on-prem — needed to call AWS without static, long-lived credentials. EKS already solves this with IRSA: annotate a ServiceAccount with an IAM role ARN, and the pod gets a projected OIDC token it exchanges with STS for temporary credentials. We wanted that exact developer experience on any cluster with an OIDC issuer, with zero changes to application code or the AWS SDK.
+
+## Decision
+
+Build a **mutating admission webhook** that is wire-compatible with EKS IRSA:
+
+- Read the `eks.amazonaws.com/role-arn` annotation from the pod's **ServiceAccount** (live `Get` at admission time), not from the pod.
+- Inject the same projected token volume (`sts.amazonaws.com` audience), mount path, and `AWS_*` env vars EKS uses, so the unmodified AWS SDK resolves credentials identically.
+- Ship as a single flat `package main` — no `internal/`/`pkg/` layering — served over TLS via Gin (`POST /mutate`, `GET /healthz`).
+
+## Consequences
+
+- Existing EKS tooling, IAM trust policies, and SDK behavior work unchanged — the injected shape is a hard contract (see `ARCHITECTURE.md`).
+- The webhook needs RBAC `get` on `serviceaccounts`, and makes a live API call inside the admission path — coupling webhook latency/availability to the API server.
+- Flat package keeps the codebase small and readable but constrains growth; the strict `funlen`/`cyclop` limits (see `docs/coding-style.md`) enforce decomposition into small functions instead of layers.
+
+## Alternatives Considered
+
+- **Use `aws/amazon-eks-pod-identity-webhook` directly** — heavier, EKS-oriented, and harder to bend to our non-EKS deployment and TLS story; a focused reimplementation was simpler to own.
+- **Credential sidecar / init container** — requires changing pod specs or app images; less transparent than admission-time injection.
+- **Post-hoc controller reconciling pods** — can't mutate the pod before it's scheduled; racy and weaker than an admission gate.

--- a/docs/adr/0002-helm-chart-in-dedicated-repo.md
+++ b/docs/adr/0002-helm-chart-in-dedicated-repo.md
@@ -1,0 +1,26 @@
+# ADR-0002: Helm chart lives in a dedicated repo
+
+- **Status:** accepted
+- **Date:** 2025-06-06
+
+> Backfilled from #10 ("relocate Helm chart to a dedicated repo"). The chart was originally added in-repo (#4) and moved out the next day.
+
+## Context
+
+The Helm chart shipped inside this repository at first. That tied every chart tweak to an app release, forced chart-only changes through the app's CI, and didn't fit how the org publishes charts — a single community index (`mondu-ai/helm-charts-community`, served via GitHub Pages) that users `helm repo add`.
+
+## Decision
+
+Move the chart out to `mondu-ai/helm-charts-community`. This repo ships only the Go binary and the container image (`ghcr.io`). The chart owns the Deployment, RBAC, Service, MutatingWebhookConfiguration, and TLS wiring.
+
+## Consequences
+
+- Chart and app version and release independently.
+- The Deployment's **RBAC lives in the chart repo**, so a change here that needs new Kubernetes permissions (e.g. a new API call beyond the ServiceAccount `Get`) requires a coordinated PR over there — this is the single most important cross-repo coupling to remember.
+- E2E tests can't use an in-repo chart; they pull the *published* one (see ADR-0003), which means e2e validates the real chart contract but is tied to whatever version is published.
+- Contributors touching install/deploy behavior have to know to look in a second repo.
+
+## Alternatives Considered
+
+- **Keep the chart in-repo** — simplest for a single consumer, but couples releases and diverges from the org's chart-index convention.
+- **Raw manifests / kustomize only** — no `helm repo add` UX; the local `tmp/manifests/` remain only as a dev-time reference.

--- a/docs/adr/0003-e2e-via-separate-module-kind-and-published-chart.md
+++ b/docs/adr/0003-e2e-via-separate-module-kind-and-published-chart.md
@@ -1,0 +1,27 @@
+# ADR-0003: E2E tests via a separate module, Kind, and the published chart
+
+- **Status:** accepted
+- **Date:** 2026-01-02
+
+> Backfilled from #30 ("add e2e tests with kind").
+
+## Context
+
+The unit tests in `main_test.go` cover patch construction well, but they mock the Kubernetes client and never exercise the real admission wiring: TLS handshake with the API server, RBAC, the MutatingWebhookConfiguration, and the Helm chart that assembles all of it. A bug in any of those is invisible to unit tests. Since the chart now lives in a separate repo (ADR-0002), chart/app drift is a real failure mode with no in-repo signal.
+
+## Decision
+
+Add end-to-end tests as a **separate Go module** under `e2e/`. `TestMain` builds the local image as `eks-pod-identity-webhook:e2e-test`, provisions a Kind cluster, and installs the webhook using the **published Helm chart** with `image.pullPolicy=Never` and `certManager.enabled=false`.
+
+## Consequences
+
+- E2E exercises the real chart contract against a real API server — it catches chart/app drift the unit tests can't.
+- Heavy test-only dependencies (`sigs.k8s.io/kind`, etc.) stay out of the app's `go.mod`, and `e2e/` is excluded from the root's lint/vet/security/`go test ./...` — so `cd e2e` is required to work on it.
+- Requires Docker, and the whole suite shares one cluster via `TestMain`; a single e2e test can't run without the cluster bootstrap.
+- The suite is tied to whatever chart version is currently published upstream.
+
+## Alternatives Considered
+
+- **envtest / controller-runtime test env** — fast, but no real chart, no real MutatingWebhookConfiguration wiring; wouldn't catch chart drift.
+- **Test against local `tmp/manifests/`** — validates manifests we don't actually ship, not the chart users install.
+- **Single module with build tags** — pollutes the app's dependency graph with test-only k8s tooling.

--- a/docs/adr/0004-tls-cert-hot-reload-via-certwatcher.md
+++ b/docs/adr/0004-tls-cert-hot-reload-via-certwatcher.md
@@ -1,0 +1,27 @@
+# ADR-0004: TLS certificate hot-reload via certwatcher
+
+- **Status:** accepted
+- **Date:** 2026-04-26
+
+> Backfilled from #60 ("TLS certificate hot-reloading via certwatcher").
+
+## Context
+
+The webhook serves TLS on `:8443`, and its serving cert is rotated periodically (cert-manager renewals). With the cert loaded once at startup, a rotation left the process serving a stale certificate until the pod was restarted — a window in which the API server can reject the webhook's cert and, because admission is in the pod-creation path, disrupt scheduling cluster-wide.
+
+## Decision
+
+Serve the certificate through controller-runtime's `certwatcher`, wired into `tls.Config.GetCertificate`. The watcher runs as a goroutine started in `startServer` and is cancelled via context on shutdown; the cert is resolved per-handshake, so a rotated secret is picked up live.
+
+## Consequences
+
+- Certificate rotation requires **no pod restart**; the disruption window is closed.
+- Adds a controller-runtime dependency (for `certwatcher` only).
+- Certificate resolution moves to per-connection (`GetCertificate`) instead of a static `Certificates` slice.
+- An e2e test (`TestCertificateHotReload`) asserts the webhook keeps working across a rotation — this behavior is now covered, not incidental.
+
+## Alternatives Considered
+
+- **Restart the pod on rotation** — disruptive and defeats the point of graceful renewal.
+- **Hand-rolled fsnotify watcher** — reinvents `certwatcher`, which already handles the atomic-rename semantics of mounted secret updates.
+- **SIGHUP-triggered reload** — needs external orchestration to send the signal; `certwatcher` reacts to the filesystem directly.

--- a/docs/adr/0005-role-session-name-derivation-and-sanitization.md
+++ b/docs/adr/0005-role-session-name-derivation-and-sanitization.md
@@ -1,0 +1,29 @@
+# ADR-0005: AWS_ROLE_SESSION_NAME derivation and sanitization
+
+- **Status:** accepted
+- **Date:** 2026-01-02
+
+> Backfilled from #11 ("handle empty pod names", 2025-06-19) and #29 ("sanitize AWS_ROLE_SESSION_NAME", 2026-01-02), which together settled the contract.
+
+## Context
+
+The injected env includes `AWS_ROLE_SESSION_NAME`, which surfaces in CloudTrail and STS audit logs. Two problems made a naive `pod.Name` wrong:
+
+- Pods created by controllers (Deployments, Jobs) have **no `.Name` at admission time** — only `generateName`. Using `pod.Name` yielded empty session names (#11).
+- AWS STS restricts session names to `[A-Za-z0-9+=,.@_-]` and caps length at 64; Kubernetes names and namespaces can contain characters STS rejects (#29).
+
+## Decision
+
+Derive the session name via a fallback chain in `generateRoleSessionName`: `pod.Name` → `generateName` + `UnixNano` → `namespace-serviceaccount` → `namespace-pod`. Then `sanitizeSessionName` maps any out-of-charset byte to `-`, and the result is truncated to 64 characters.
+
+## Consequences
+
+- Every injected pod gets a valid, non-empty session name, including controller-created pods before their name is assigned.
+- The `UnixNano` suffix gives uniqueness when many pods share a `generateName` in the same second.
+- Sanitization is **lossy** — distinct source names can collide after invalid characters collapse to `-`. Accepted: session names are for traceability, not identity.
+
+## Alternatives Considered
+
+- **Leave `AWS_ROLE_SESSION_NAME` unset** — the SDK auto-generates one, but it's opaque and useless for correlating activity back to a pod.
+- **Use the pod UID** — unique and always present, but meaningless in CloudTrail.
+- **Require a pod name** — would reject controller-created pods, breaking the common case.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,21 @@
+# Architecture Decision Records
+
+An ADR captures a single architectural decision — the context that forced it, what was decided, and the consequences we accept. They exist so the *why* survives after the people who made the call move on.
+
+## When to write one
+
+Write an ADR when a decision is hard to reverse or shapes the system going forward. For this project that includes things like:
+
+- Changing anything in the EKS IRSA injection contract (annotation key, token audience, mount path, env var set) — these are load-bearing and any deviation must be justified in writing.
+- Altering the fail-open / fail-closed admission semantics.
+- Moving off the flat single-package layout, or splitting into more modules.
+- Changing the deployment/distribution model (chart source, registry, TLS strategy, cert-manager vs. baked certs).
+- Adopting or dropping a core dependency (Gin, controller-runtime certwatcher, the k8s client).
+
+Skip ADRs for routine changes — bug fixes, dependency bumps, refactors that don't change a contract.
+
+## Convention
+
+- Filename: `NNNN-kebab-case-title.md`, zero-padded sequential number — e.g. `0001-flat-single-package-layout.md`, `0002-certwatcher-tls-hot-reload.md`. Easy to reference ("see ADR-2"), trivially sortable.
+- Copy `TEMPLATE.md` to start.
+- ADRs are **immutable once accepted.** Don't rewrite history — to change a decision, write a new ADR that supersedes the old one and link both ways (set the old one's status to `superseded by ADR-N`).

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,20 @@
+# ADR-NNNN: <short title of the decision>
+
+- **Status:** proposed <!-- proposed | accepted | superseded by ADR-N -->
+- **Date:** YYYY-MM-DD
+
+## Context
+
+What forces this decision? The problem, the constraints, the relevant facts. What's true *now* that makes this necessary. No solution yet.
+
+## Decision
+
+What we're doing, stated plainly and in the active voice: "We will …". One decision per ADR.
+
+## Consequences
+
+What becomes easier, what becomes harder, what we now have to live with. Include the downsides honestly — an ADR with only upsides is hiding something.
+
+## Alternatives Considered
+
+The other options and why they lost. This is the part future-you will thank present-you for.

--- a/docs/coding-style.md
+++ b/docs/coding-style.md
@@ -1,0 +1,44 @@
+# Coding Style
+
+Codified from `.golangci.yml` (golangci-lint **v2**, pinned to `v2.12.2`) and the de-facto patterns in `main.go`. The linter is the source of truth — when in doubt, run `make lint`.
+
+## Formatting & tooling
+
+- **`make fmt`** runs `go fmt` + `goimports`. Formatting is non-negotiable; CI runs `make ci` which includes it.
+- **`make lint`** installs the pinned golangci-lint and runs it over the root module. `make vet`, `make security` (gosec → `results.sarif`) round out the checks. All three exclude `e2e/` (separate module).
+- **`make test`** — unit tests with `-race -timeout=30s`.
+
+## Enforced limits (they fail CI)
+
+- **Function length** (`funlen`): 100 lines / 50 statements. This is *why* the code is a flat package of small methods rather than a few big handlers — don't grow a function past the limit, decompose it.
+- **Cyclomatic complexity** (`cyclop`, `gocyclo`): 15 max.
+- **Duplication** (`dupl`): 100-token threshold — extract shared logic instead of copy-paste.
+- **Naked returns** (`nakedret`): only in functions ≤30 lines.
+- **Magic strings** (`goconst`): a string literal ≥3 chars appearing ≥3 times must be a named const. (See the const block at the top of `main.go`.)
+
+Test files (`_test.go`) are exempt from `gosec`, `funlen`, `goconst`, `dupl`, `gocyclo`. `e2e/` is excluded entirely.
+
+## Error handling
+
+- **Wrap with context:** `fmt.Errorf("failed to get ServiceAccount %s/%s: %w", ns, name, err)`. `errorlint` enforces `%w` and correct comparison; `errname` enforces sentinel `ErrXxx` / type `XxxError` naming.
+- **`errcheck` is strict:** `check-type-assertions` and `check-blank` are on. You must handle the `ok` of a type assertion and cannot silently `_ =` an error to dodge the check — if you genuinely intend to ignore one (e.g. cleanup in a `defer`), annotate it: `//nolint:errcheck // cleanup in defer` (as the e2e tests do).
+- **Flat error checks, no nesting.** `errors.Is(err, sentinel)` first, then `if err != nil`. Never `if err != nil { if errors.Is(...) }`.
+
+## Naming, comments, structure
+
+- **`govet` runs `enable-all`** (minus `fieldalignment` and `shadow`). Expect strict vet.
+- **`revive` requires:** doc comments on exported identifiers (`exported`), a package comment (`package-comments` — see the top of `main.go`), Go-idiomatic names (`var-naming`), error-return / error-naming conventions.
+- **File declaration order:** `const` → `var` → `type` → exported functions → unexported functions. Keep declarations grouped at the top, not scattered between functions. `main.go` already follows this.
+- **Comment the WHY, not the WHAT.** The existing `#nosec Gxxx - <reason>` inline comments are the model: terse, justify a specific decision (why a constant that looks like a secret isn't). No narration, no restating the code.
+- **Leveled logging only.** Use `logInfo`/`logWarn`/`logError`/`logDebug` (+ `f` variants). No bare `fmt.Println`/`log.Print`. `LOG_LEVEL=debug` gates the debug logger.
+
+## gosec
+
+Severity and confidence both `medium`. Standard-but-secret-looking constants (env var names, mount paths, audiences) are annotated inline with `#nosec G101 - <reason>` — follow that pattern rather than disabling the linter globally.
+
+## Architecture-level rules
+
+- **Stay flat.** One `package main` at root. Don't introduce `internal/`/`pkg/` layering unless a genuine reusable boundary emerges — the small-function decomposition is the intended shape, not a stopgap.
+- **Keep the two modules separate.** Root and `e2e/` are independent Go modules. Don't import the e2e framework from the webhook or vice versa.
+- **Don't touch the IRSA contract constants' *values*.** They're wire-compatible with EKS by design (see `ARCHITECTURE.md`). Renaming the Go identifier is fine; changing the string/number it holds is a breaking change.
+- **Preserve idempotency and fail semantics.** New injection logic must check-before-add (never overwrite user config) and keep the allow-non-pod / deny-on-error asymmetry.


### PR DESCRIPTION
## Why

The repo had no architecture documentation and nothing to orient a new contributor to how the webhook actually behaves. Several of its properties are subtle and easy to break by accident:

- The injected shape is **wire-compatible with EKS IRSA** — the `eks.amazonaws.com/role-arn` annotation, the `sts.amazonaws.com` token audience, the mount path, and the `AWS_*` env var names are a hard contract, not free variables. Change one and every consumer's credential resolution breaks silently.
- Admission is **fail-open for non-pods but fail-closed on error**, and injection is idempotent (never overwrites user-set env). That asymmetry is deliberate and worth stating.
- The RBAC the webhook depends on lives in a **separate chart repo**, so a change here can silently require a change there.

None of that was written down anywhere.

## What

- **`ARCHITECTURE.md`** — runtime shape, the `/mutate` request lifecycle, the IRSA injection contract, the behavioral invariants, the two Go modules (app + `e2e`), and greppable commands for detecting when the doc drifts from the code.
- **`docs/coding-style.md`** — codified from the existing `.golangci.yml`. The strict `funlen`/`cyclop` limits are the reason the code is a flat package of small functions rather than layered; this writes that down alongside the de-facto error-wrapping and logging conventions.
- **`docs/adr/`** — an ADR log (README + template) with five decisions backfilled from git history: the webhook design, moving the Helm chart to its own repo, the Kind-based e2e module, certwatcher TLS hot-reload, and the role-session-name derivation.
- **`CLAUDE.md`** — read order and non-negotiables for agents working in the repo.

## Notes

Docs only — no code or behavior changes. The ADRs are explicitly marked as backfilled and dated to the commit that introduced each decision, so they don't pretend to be contemporaneous.
