### PR TITLE
chore: update LICENSE copyright year to 2025-2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 EKS Pod Identity Webhook Contributors
+Copyright (c) 2025-2026 EKS Pod Identity Webhook Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The LICENSE copyright year was still 2025. Updated to 2025-2026 to reflect the current year.